### PR TITLE
soc_info.c: add watchdog support to F1C100s

### DIFF
--- a/fel-remotefunc-compiler.rb
+++ b/fel-remotefunc-compiler.rb
@@ -72,7 +72,7 @@ toolchain = toolchains.find { |toolchain| tool_exists("#{toolchain}gcc") }
 abort "Can't find any usable ARM crosscompiler.\n" unless toolchain
 
 # Compile the source file
-system("#{toolchain}gcc -c -O3 -marm -march=armv7-a -mfloat-abi=soft -fstack-usage -fpic -o #{ARGV[0]}.o #{ARGV[0]}")
+system("#{toolchain}gcc -c -Os -marm -march=armv5te -mfloat-abi=soft -fstack-usage -fpic -o #{ARGV[0]}.o #{ARGV[0]}")
 exit($?.to_i) if $?.to_i != 0
 
 # Read the stack usage information

--- a/fel-remotefunc-spi-data-transfer.h
+++ b/fel-remotefunc-spi-data-transfer.h
@@ -13,127 +13,124 @@ aw_fel_remotefunc_prepare_spi_batch_data_transfer(feldev_handle *dev,
                                                   uint32_t              spi_bcc_reg)
 {
 	static uint8_t arm_code[] = {
-		0xf0, 0x0f, 0x2d, 0xe9, /*    0:    push     {r4, r5, r6, r7, r8, r9, sl, fp}   */
-		0x18, 0xd0, 0x4d, 0xe2, /*    4:    sub      sp, sp, #24                        */
-		0x38, 0x50, 0x9d, 0xe5, /*    8:    ldr      r5, [sp, #56]                      */
-		0x3c, 0x60, 0x9d, 0xe5, /*    c:    ldr      r6, [sp, #60]                      */
-		0x06, 0x00, 0x8d, 0xe9, /*   10:    stmib    sp, {r1, r2}                       */
-		0x00, 0xa0, 0xd0, 0xe5, /*   14:    ldrb     sl, [r0]                           */
-		0x01, 0x20, 0xd0, 0xe5, /*   18:    ldrb     r2, [r0, #1]                       */
-		0x0a, 0xa4, 0x92, 0xe1, /*   1c:    orrs     sl, r2, sl, lsl #8                 */
-		0x6a, 0x00, 0x00, 0x0a, /*   20:    beq      1d0 <spi_batch_data_transfer+0x1d0> */
-		0xff, 0x2f, 0x0f, 0xe3, /*   24:    movw     r2, #65535                         */
-		0x02, 0x00, 0x5a, 0xe1, /*   28:    cmp      sl, r2                             */
-		0x18, 0x80, 0x8d, 0x02, /*   2c:    addeq    r8, sp, #24                        */
-		0x02, 0x80, 0x80, 0x12, /*   30:    addne    r8, r0, #2                         */
-		0x05, 0xb0, 0xa0, 0x03, /*   34:    moveq    fp, #5                             */
-		0x48, 0xc0, 0x9d, 0xe5, /*   38:    ldr      ip, [sp, #72]                      */
-		0x08, 0xb0, 0x68, 0x05, /*   3c:    strbeq   fp, [r8, #-8]!                     */
-		0x00, 0x10, 0x68, 0xe2, /*   40:    rsb      r1, r8, #0                         */
-		0x40, 0x20, 0x9d, 0xe5, /*   44:    ldr      r2, [sp, #64]                      */
-		0x03, 0x10, 0x01, 0xe2, /*   48:    and      r1, r1, #3                         */
-		0x44, 0xb0, 0x9d, 0xe5, /*   4c:    ldr      fp, [sp, #68]                      */
-		0x0a, 0x70, 0xa0, 0x11, /*   50:    movne    r7, sl                             */
-		0x0c, 0x00, 0x8d, 0x05, /*   54:    streq    r0, [sp, #12]                      */
-		0x3c, 0x00, 0x81, 0xe2, /*   58:    add      r0, r1, #60                        */
-		0x02, 0x70, 0xa0, 0x03, /*   5c:    moveq    r7, #2                             */
-		0x00, 0x00, 0x5c, 0xe3, /*   60:    cmp      ip, #0                             */
-		0x00, 0x70, 0x82, 0xe5, /*   64:    str      r7, [r2]                           */
-		0x08, 0x20, 0xa0, 0xe1, /*   68:    mov      r2, r8                             */
-		0x00, 0x70, 0x8b, 0xe5, /*   6c:    str      r7, [fp]                           */
-		0x00, 0x70, 0x8c, 0x15, /*   70:    strne    r7, [ip]                           */
-		0x07, 0x00, 0x50, 0xe1, /*   74:    cmp      r0, r7                             */
-		0x07, 0x00, 0xa0, 0x21, /*   78:    movcs    r0, r7                             */
-		0x00, 0x40, 0x88, 0xe0, /*   7c:    add      r4, r8, r0                         */
-		0x01, 0xc0, 0xd2, 0xe4, /*   80:    ldrb     ip, [r2], #1                       */
-		0x04, 0x00, 0x52, 0xe1, /*   84:    cmp      r2, r4                             */
-		0x00, 0xc0, 0xc5, 0xe5, /*   88:    strb     ip, [r5]                           */
-		0xfb, 0xff, 0xff, 0x1a, /*   8c:    bne      80 <spi_batch_data_transfer+0x80>  */
-		0x07, 0x00, 0x60, 0xe0, /*   90:    rsb      r0, r0, r7                         */
-		0x00, 0x90, 0x0f, 0xe1, /*   94:    mrs      r9, CPSR                           */
-		0xc0, 0xc0, 0x89, 0xe3, /*   98:    orr      ip, r9, #192                       */
-		0x0c, 0xf0, 0x21, 0xe1, /*   9c:    msr      CPSR_c, ip                         */
-		0x04, 0xc0, 0x9d, 0xe5, /*   a0:    ldr      ip, [sp, #4]                       */
-		0x07, 0x00, 0x51, 0xe1, /*   a4:    cmp      r1, r7                             */
-		0x07, 0x10, 0xa0, 0x21, /*   a8:    movcs    r1, r7                             */
-		0x08, 0xb0, 0x9d, 0xe5, /*   ac:    ldr      fp, [sp, #8]                       */
-		0x00, 0x40, 0x9c, 0xe5, /*   b0:    ldr      r4, [ip]                           */
-		0x01, 0xc0, 0x88, 0xe0, /*   b4:    add      ip, r8, r1                         */
-		0x00, 0xc0, 0x8d, 0xe5, /*   b8:    str      ip, [sp]                           */
-		0x08, 0xc0, 0xa0, 0xe1, /*   bc:    mov      ip, r8                             */
-		0x0b, 0x40, 0x84, 0xe1, /*   c0:    orr      r4, r4, fp                         */
-		0x04, 0xb0, 0x9d, 0xe5, /*   c4:    ldr      fp, [sp, #4]                       */
-		0x00, 0x40, 0x8b, 0xe5, /*   c8:    str      r4, [fp]                           */
-		0x00, 0xb0, 0x9d, 0xe5, /*   cc:    ldr      fp, [sp]                           */
-		0x0b, 0x00, 0x5c, 0xe1, /*   d0:    cmp      ip, fp                             */
-		0x06, 0x00, 0x00, 0x0a, /*   d4:    beq      f4 <spi_batch_data_transfer+0xf4>  */
-		0x00, 0x40, 0x93, 0xe5, /*   d8:    ldr      r4, [r3]                           */
-		0x7f, 0x00, 0x14, 0xe3, /*   dc:    tst      r4, #127                           */
-		0xfc, 0xff, 0xff, 0x0a, /*   e0:    beq      d8 <spi_batch_data_transfer+0xd8>  */
-		0x00, 0x40, 0xd6, 0xe5, /*   e4:    ldrb     r4, [r6]                           */
-		0x01, 0x40, 0xcc, 0xe4, /*   e8:    strb     r4, [ip], #1                       */
-		0x0b, 0x00, 0x5c, 0xe1, /*   ec:    cmp      ip, fp                             */
-		0xf8, 0xff, 0xff, 0x1a, /*   f0:    bne      d8 <spi_batch_data_transfer+0xd8>  */
-		0x07, 0x10, 0x61, 0xe0, /*   f4:    rsb      r1, r1, r7                         */
-		0x03, 0x00, 0x51, 0xe3, /*   f8:    cmp      r1, #3                             */
-		0x12, 0x00, 0x00, 0x9a, /*   fc:    bls      14c <spi_batch_data_transfer+0x14c> */
-		0x00, 0x40, 0x93, 0xe5, /*  100:    ldr      r4, [r3]                           */
-		0x7f, 0xb0, 0x04, 0xe2, /*  104:    and      fp, r4, #127                       */
-		0x54, 0x48, 0xe6, 0xe7, /*  108:    ubfx     r4, r4, #16, #7                    */
-		0x03, 0x00, 0x5b, 0xe3, /*  10c:    cmp      fp, #3                             */
-		0x04, 0x10, 0x41, 0xc2, /*  110:    subgt    r1, r1, #4                         */
-		0x00, 0xb0, 0x96, 0xc5, /*  114:    ldrgt    fp, [r6]                           */
-		0x04, 0xb0, 0x8c, 0xc4, /*  118:    strgt    fp, [ip], #4                       */
-		0x03, 0x00, 0x50, 0xe3, /*  11c:    cmp      r0, #3                             */
-		0x00, 0xb0, 0xa0, 0x93, /*  120:    movls    fp, #0                             */
-		0x01, 0xb0, 0xa0, 0x83, /*  124:    movhi    fp, #1                             */
-		0x3b, 0x00, 0x54, 0xe3, /*  128:    cmp      r4, #59                            */
-		0x00, 0xb0, 0xa0, 0xc3, /*  12c:    movgt    fp, #0                             */
-		0x00, 0x00, 0x5b, 0xe3, /*  130:    cmp      fp, #0                             */
-		0xef, 0xff, 0xff, 0x0a, /*  134:    beq      f8 <spi_batch_data_transfer+0xf8>  */
-		0x04, 0x40, 0x92, 0xe4, /*  138:    ldr      r4, [r2], #4                       */
-		0x03, 0x00, 0x51, 0xe3, /*  13c:    cmp      r1, #3                             */
-		0x04, 0x00, 0x40, 0xe2, /*  140:    sub      r0, r0, #4                         */
-		0x00, 0x40, 0x85, 0xe5, /*  144:    str      r4, [r5]                           */
-		0xec, 0xff, 0xff, 0x8a, /*  148:    bhi      100 <spi_batch_data_transfer+0x100> */
-		0x00, 0x00, 0x51, 0xe3, /*  14c:    cmp      r1, #0                             */
-		0x10, 0x00, 0x00, 0x0a, /*  150:    beq      198 <spi_batch_data_transfer+0x198> */
-		0x00, 0x40, 0x93, 0xe5, /*  154:    ldr      r4, [r3]                           */
-		0x7f, 0x00, 0x14, 0xe3, /*  158:    tst      r4, #127                           */
-		0x54, 0x48, 0xe6, 0xe7, /*  15c:    ubfx     r4, r4, #16, #7                    */
-		0x01, 0x10, 0x41, 0x12, /*  160:    subne    r1, r1, #1                         */
-		0x00, 0xb0, 0xd6, 0x15, /*  164:    ldrbne   fp, [r6]                           */
-		0x01, 0xb0, 0xcc, 0x14, /*  168:    strbne   fp, [ip], #1                       */
-		0x00, 0xb0, 0x90, 0xe2, /*  16c:    adds     fp, r0, #0                         */
-		0x01, 0xb0, 0xa0, 0x13, /*  170:    movne    fp, #1                             */
-		0x3b, 0x00, 0x54, 0xe3, /*  174:    cmp      r4, #59                            */
-		0x00, 0xb0, 0xa0, 0xc3, /*  178:    movgt    fp, #0                             */
-		0x00, 0x00, 0x5b, 0xe3, /*  17c:    cmp      fp, #0                             */
-		0xf1, 0xff, 0xff, 0x0a, /*  180:    beq      14c <spi_batch_data_transfer+0x14c> */
-		0x01, 0x40, 0xd2, 0xe4, /*  184:    ldrb     r4, [r2], #1                       */
-		0x00, 0x00, 0x51, 0xe3, /*  188:    cmp      r1, #0                             */
-		0x01, 0x00, 0x40, 0xe2, /*  18c:    sub      r0, r0, #1                         */
-		0x00, 0x40, 0xc5, 0xe5, /*  190:    strb     r4, [r5]                           */
-		0xee, 0xff, 0xff, 0x1a, /*  194:    bne      154 <spi_batch_data_transfer+0x154> */
-		0x09, 0xf0, 0x21, 0xe1, /*  198:    msr      CPSR_c, r9                         */
-		0xff, 0xcf, 0x0f, 0xe3, /*  19c:    movw     ip, #65535                         */
-		0x0c, 0x00, 0x5a, 0xe1, /*  1a0:    cmp      sl, ip                             */
-		0x07, 0x00, 0x88, 0x10, /*  1a4:    addne    r0, r8, r7                         */
-		0x99, 0xff, 0xff, 0x1a, /*  1a8:    bne      14 <spi_batch_data_transfer+0x14>  */
-		0x11, 0x20, 0xdd, 0xe5, /*  1ac:    ldrb     r2, [sp, #17]                      */
-		0x01, 0x00, 0x12, 0xe3, /*  1b0:    tst      r2, #1                             */
-		0x08, 0x00, 0x00, 0x1a, /*  1b4:    bne      1dc <spi_batch_data_transfer+0x1dc> */
-		0x0c, 0xb0, 0x9d, 0xe5, /*  1b8:    ldr      fp, [sp, #12]                      */
-		0x02, 0x00, 0x8b, 0xe2, /*  1bc:    add      r0, fp, #2                         */
-		0x00, 0xa0, 0xd0, 0xe5, /*  1c0:    ldrb     sl, [r0]                           */
-		0x01, 0x20, 0xd0, 0xe5, /*  1c4:    ldrb     r2, [r0, #1]                       */
-		0x0a, 0xa4, 0x92, 0xe1, /*  1c8:    orrs     sl, r2, sl, lsl #8                 */
-		0x94, 0xff, 0xff, 0x1a, /*  1cc:    bne      24 <spi_batch_data_transfer+0x24>  */
-		0x18, 0xd0, 0x8d, 0xe2, /*  1d0:    add      sp, sp, #24                        */
-		0xf0, 0x0f, 0xbd, 0xe8, /*  1d4:    pop      {r4, r5, r6, r7, r8, r9, sl, fp}   */
-		0x1e, 0xff, 0x2f, 0xe1, /*  1d8:    bx       lr                                 */
-		0x0c, 0x00, 0x9d, 0xe5, /*  1dc:    ldr      r0, [sp, #12]                      */
-		0x8b, 0xff, 0xff, 0xea, /*  1e0:    b        14 <spi_batch_data_transfer+0x14>  */
+		0xf0, 0x4f, 0x2d, 0xe9, /*    0:    push     {r4, r5, r6, r7, r8, r9, sl, fp, lr} */
+		0xc8, 0x91, 0x9f, 0xe5, /*    4:    ldr      r9, [pc, #456]                     */
+		0x14, 0xd0, 0x4d, 0xe2, /*    8:    sub      sp, sp, #20                        */
+		0x00, 0x20, 0x8d, 0xe5, /*    c:    str      r2, [sp]                           */
+		0x0c, 0x20, 0x8d, 0xe2, /*   10:    add      r2, sp, #12                        */
+		0x04, 0x20, 0x8d, 0xe5, /*   14:    str      r2, [sp, #4]                       */
+		0x01, 0x60, 0xd0, 0xe5, /*   18:    ldrb     r6, [r0, #1]                       */
+		0x00, 0x20, 0xd0, 0xe5, /*   1c:    ldrb     r2, [r0]                           */
+		0x06, 0x24, 0x82, 0xe1, /*   20:    orr      r2, r2, r6, lsl #8                 */
+		0x22, 0x64, 0xa0, 0xe1, /*   24:    lsr      r6, r2, #8                         */
+		0x02, 0x64, 0x86, 0xe1, /*   28:    orr      r6, r6, r2, lsl #8                 */
+		0x06, 0x68, 0xa0, 0xe1, /*   2c:    lsl      r6, r6, #16                        */
+		0x26, 0x68, 0xa0, 0xe1, /*   30:    lsr      r6, r6, #16                        */
+		0x00, 0x00, 0x56, 0xe3, /*   34:    cmp      r6, #0                             */
+		0x63, 0x00, 0x00, 0x0a, /*   38:    beq      1cc <spi_batch_data_transfer+0x1cc> */
+		0x09, 0x00, 0x56, 0xe1, /*   3c:    cmp      r6, r9                             */
+		0x05, 0x20, 0xa0, 0x03, /*   40:    moveq    r2, #5                             */
+		0x0c, 0x20, 0xcd, 0x05, /*   44:    strbeq   r2, [sp, #12]                      */
+		0x40, 0x20, 0x9d, 0xe5, /*   48:    ldr      r2, [sp, #64]                      */
+		0x06, 0x50, 0xa0, 0x11, /*   4c:    movne    r5, r6                             */
+		0x02, 0x50, 0xa0, 0x03, /*   50:    moveq    r5, #2                             */
+		0x00, 0x50, 0x82, 0xe5, /*   54:    str      r5, [r2]                           */
+		0x44, 0x20, 0x9d, 0xe5, /*   58:    ldr      r2, [sp, #68]                      */
+		0x00, 0x70, 0xa0, 0x01, /*   5c:    moveq    r7, r0                             */
+		0x00, 0x50, 0x82, 0xe5, /*   60:    str      r5, [r2]                           */
+		0x48, 0x20, 0x9d, 0xe5, /*   64:    ldr      r2, [sp, #72]                      */
+		0x04, 0x00, 0x9d, 0x05, /*   68:    ldreq    r0, [sp, #4]                       */
+		0x02, 0x00, 0x80, 0x12, /*   6c:    addne    r0, r0, #2                         */
+		0x00, 0x00, 0x52, 0xe3, /*   70:    cmp      r2, #0                             */
+		0x00, 0x50, 0x82, 0x15, /*   74:    strne    r5, [r2]                           */
+		0x00, 0x20, 0x60, 0xe2, /*   78:    rsb      r2, r0, #0                         */
+		0x03, 0x20, 0x02, 0xe2, /*   7c:    and      r2, r2, #3                         */
+		0x3c, 0x40, 0x82, 0xe2, /*   80:    add      r4, r2, #60                        */
+		0x04, 0x00, 0x55, 0xe1, /*   84:    cmp      r5, r4                             */
+		0x05, 0x40, 0xa0, 0x31, /*   88:    movcc    r4, r5                             */
+		0x04, 0xe0, 0x80, 0xe0, /*   8c:    add      lr, r0, r4                         */
+		0x00, 0xc0, 0xa0, 0xe1, /*   90:    mov      ip, r0                             */
+		0x0e, 0x00, 0x5c, 0xe1, /*   94:    cmp      ip, lr                             */
+		0x1b, 0x00, 0x00, 0x1a, /*   98:    bne      10c <spi_batch_data_transfer+0x10c> */
+		0x04, 0x40, 0x45, 0xe0, /*   9c:    sub      r4, r5, r4                         */
+		0x00, 0xa0, 0x0f, 0xe1, /*   a0:    mrs      sl, CPSR                           */
+		0xc0, 0xc0, 0x8a, 0xe3, /*   a4:    orr      ip, sl, #192                       */
+		0x0c, 0xf0, 0x21, 0xe1, /*   a8:    msr      CPSR_c, ip                         */
+		0x00, 0xc0, 0x91, 0xe5, /*   ac:    ldr      ip, [r1]                           */
+		0x00, 0x80, 0x9d, 0xe5, /*   b0:    ldr      r8, [sp]                           */
+		0x02, 0x00, 0x55, 0xe1, /*   b4:    cmp      r5, r2                             */
+		0x0c, 0xc0, 0x88, 0xe1, /*   b8:    orr      ip, r8, ip                         */
+		0x05, 0x20, 0xa0, 0x31, /*   bc:    movcc    r2, r5                             */
+		0x00, 0xc0, 0x81, 0xe5, /*   c0:    str      ip, [r1]                           */
+		0x02, 0x80, 0x80, 0xe0, /*   c4:    add      r8, r0, r2                         */
+		0x00, 0xc0, 0xa0, 0xe1, /*   c8:    mov      ip, r0                             */
+		0x0c, 0x00, 0x58, 0xe1, /*   cc:    cmp      r8, ip                             */
+		0x11, 0x00, 0x00, 0x1a, /*   d0:    bne      11c <spi_batch_data_transfer+0x11c> */
+		0x02, 0x20, 0x45, 0xe0, /*   d4:    sub      r2, r5, r2                         */
+		0x03, 0x00, 0x52, 0xe3, /*   d8:    cmp      r2, #3                             */
+		0x14, 0x00, 0x00, 0x8a, /*   dc:    bhi      134 <spi_batch_data_transfer+0x134> */
+		0x00, 0x00, 0x52, 0xe3, /*   e0:    cmp      r2, #0                             */
+		0x25, 0x00, 0x00, 0x1a, /*   e4:    bne      180 <spi_batch_data_transfer+0x180> */
+		0x0a, 0xf0, 0x21, 0xe1, /*   e8:    msr      CPSR_c, sl                         */
+		0x09, 0x00, 0x56, 0xe1, /*   ec:    cmp      r6, r9                             */
+		0x05, 0x00, 0x80, 0x10, /*   f0:    addne    r0, r0, r5                         */
+		0xc7, 0xff, 0xff, 0x1a, /*   f4:    bne      18 <spi_batch_data_transfer+0x18>  */
+		0x0d, 0x20, 0xdd, 0xe5, /*   f8:    ldrb     r2, [sp, #13]                      */
+		0x01, 0x00, 0x12, 0xe3, /*   fc:    tst      r2, #1                             */
+		0x02, 0x00, 0x87, 0x02, /*  100:    addeq    r0, r7, #2                         */
+		0x07, 0x00, 0xa0, 0x11, /*  104:    movne    r0, r7                             */
+		0xc2, 0xff, 0xff, 0xea, /*  108:    b        18 <spi_batch_data_transfer+0x18>  */
+		0x38, 0xa0, 0x9d, 0xe5, /*  10c:    ldr      sl, [sp, #56]                      */
+		0x01, 0x80, 0xdc, 0xe4, /*  110:    ldrb     r8, [ip], #1                       */
+		0x00, 0x80, 0xca, 0xe5, /*  114:    strb     r8, [sl]                           */
+		0xdd, 0xff, 0xff, 0xea, /*  118:    b        94 <spi_batch_data_transfer+0x94>  */
+		0x00, 0xb0, 0x93, 0xe5, /*  11c:    ldr      fp, [r3]                           */
+		0x7f, 0x00, 0x1b, 0xe3, /*  120:    tst      fp, #127                           */
+		0x3c, 0xb0, 0x9d, 0x15, /*  124:    ldrne    fp, [sp, #60]                      */
+		0x00, 0xb0, 0xdb, 0x15, /*  128:    ldrbne   fp, [fp]                           */
+		0x01, 0xb0, 0xcc, 0x14, /*  12c:    strbne   fp, [ip], #1                       */
+		0xe5, 0xff, 0xff, 0xea, /*  130:    b        cc <spi_batch_data_transfer+0xcc>  */
+		0x00, 0xb0, 0x93, 0xe5, /*  134:    ldr      fp, [r3]                           */
+		0x7c, 0x00, 0x1b, 0xe3, /*  138:    tst      fp, #124                           */
+		0x2b, 0x88, 0xa0, 0xe1, /*  13c:    lsr      r8, fp, #16                        */
+		0x3c, 0xb0, 0x9d, 0x15, /*  140:    ldrne    fp, [sp, #60]                      */
+		0x7f, 0x80, 0x08, 0xe2, /*  144:    and      r8, r8, #127                       */
+		0x00, 0xb0, 0x9b, 0x15, /*  148:    ldrne    fp, [fp]                           */
+		0x04, 0xb0, 0x8c, 0x14, /*  14c:    strne    fp, [ip], #4                       */
+		0x04, 0x20, 0x42, 0x12, /*  150:    subne    r2, r2, #4                         */
+		0x3b, 0x00, 0x58, 0xe3, /*  154:    cmp      r8, #59                            */
+		0x00, 0x80, 0xa0, 0xc3, /*  158:    movgt    r8, #0                             */
+		0x01, 0x80, 0xa0, 0xd3, /*  15c:    movle    r8, #1                             */
+		0x03, 0x00, 0x54, 0xe3, /*  160:    cmp      r4, #3                             */
+		0x00, 0x80, 0xa0, 0x93, /*  164:    movls    r8, #0                             */
+		0x00, 0x00, 0x58, 0xe3, /*  168:    cmp      r8, #0                             */
+		0x38, 0xb0, 0x9d, 0x15, /*  16c:    ldrne    fp, [sp, #56]                      */
+		0x04, 0x80, 0x9e, 0x14, /*  170:    ldrne    r8, [lr], #4                       */
+		0x04, 0x40, 0x44, 0x12, /*  174:    subne    r4, r4, #4                         */
+		0x00, 0x80, 0x8b, 0x15, /*  178:    strne    r8, [fp]                           */
+		0xd5, 0xff, 0xff, 0xea, /*  17c:    b        d8 <spi_batch_data_transfer+0xd8>  */
+		0x00, 0xb0, 0x93, 0xe5, /*  180:    ldr      fp, [r3]                           */
+		0x7f, 0x00, 0x1b, 0xe3, /*  184:    tst      fp, #127                           */
+		0x2b, 0x88, 0xa0, 0xe1, /*  188:    lsr      r8, fp, #16                        */
+		0x3c, 0xb0, 0x9d, 0x15, /*  18c:    ldrne    fp, [sp, #60]                      */
+		0x7f, 0x80, 0x08, 0xe2, /*  190:    and      r8, r8, #127                       */
+		0x00, 0xb0, 0xdb, 0x15, /*  194:    ldrbne   fp, [fp]                           */
+		0x01, 0xb0, 0xcc, 0x14, /*  198:    strbne   fp, [ip], #1                       */
+		0x01, 0x20, 0x42, 0x12, /*  19c:    subne    r2, r2, #1                         */
+		0x3b, 0x00, 0x58, 0xe3, /*  1a0:    cmp      r8, #59                            */
+		0x00, 0x80, 0xa0, 0xc3, /*  1a4:    movgt    r8, #0                             */
+		0x01, 0x80, 0xa0, 0xd3, /*  1a8:    movle    r8, #1                             */
+		0x00, 0x00, 0x54, 0xe3, /*  1ac:    cmp      r4, #0                             */
+		0x00, 0x80, 0xa0, 0x03, /*  1b0:    moveq    r8, #0                             */
+		0x00, 0x00, 0x58, 0xe3, /*  1b4:    cmp      r8, #0                             */
+		0x38, 0xb0, 0x9d, 0x15, /*  1b8:    ldrne    fp, [sp, #56]                      */
+		0x01, 0x80, 0xde, 0x14, /*  1bc:    ldrbne   r8, [lr], #1                       */
+		0x01, 0x40, 0x44, 0x12, /*  1c0:    subne    r4, r4, #1                         */
+		0x00, 0x80, 0xcb, 0x15, /*  1c4:    strbne   r8, [fp]                           */
+		0xc4, 0xff, 0xff, 0xea, /*  1c8:    b        e0 <spi_batch_data_transfer+0xe0>  */
+		0x14, 0xd0, 0x8d, 0xe2, /*  1cc:    add      sp, sp, #20                        */
+		0xf0, 0x8f, 0xbd, 0xe8, /*  1d0:    pop      {r4, r5, r6, r7, r8, r9, sl, fp, pc} */
+		0xff, 0xff, 0x00, 0x00, /*  1d4:    .word    0x0000ffff                         */
 	};
 	uint32_t args[] = {
 		buf,

--- a/fel-spiflash.c
+++ b/fel-spiflash.c
@@ -80,11 +80,14 @@ void fel_writel(feldev_handle *dev, uint32_t addr, uint32_t val);
 #define CCM_AHB_GATE_SPI0           (1 << 20)
 #define SUN6I_BUS_SOFT_RST_REG0     (0x01C20000 + 0x2C0)
 #define SUN6I_SPI0_RST              (1 << 20)
+#define SUNIV_PLL6_CTL              (0x01c20000 + 0x28)
+#define SUNIV_AHB_APB_CFG           (0x01c20000 + 0x54)
 
 #define H6_CCM_SPI0_CLK             (0x03001000 + 0x940)
 #define H6_CCM_SPI_BGR              (0x03001000 + 0x96C)
 #define H6_CCM_SPI0_GATE_RESET      (1 << 0 | 1 << 16)
 
+#define SUNIV_GPC_SPI0              (2)
 #define SUNXI_GPC_SPI0              (3)
 #define SUN50I_GPC_SPI0             (4)
 
@@ -117,6 +120,7 @@ void fel_writel(feldev_handle *dev, uint32_t addr, uint32_t val);
 #define CCM_SPI0_CLK_DIV_BY_2       (0x1000)
 #define CCM_SPI0_CLK_DIV_BY_4       (0x1001)
 #define CCM_SPI0_CLK_DIV_BY_6       (0x1002)
+#define CCM_SPI0_CLK_DIV_BY_32      (0x100f)
 
 static uint32_t gpio_base(feldev_handle *dev)
 {
@@ -138,6 +142,7 @@ static uint32_t spi_base(feldev_handle *dev)
 	case 0x1623: /* A10 */
 	case 0x1625: /* A13 */
 	case 0x1651: /* A20 */
+	case 0x1663: /* F1C100s */
 	case 0x1701: /* R40 */
 		return 0x01C05000;
 	case 0x1817: /* V831 */
@@ -205,6 +210,12 @@ static bool spi0_init(feldev_handle *dev)
 
 	/* Setup SPI0 pins muxing */
 	switch (soc_info->soc_id) {
+	case 0x1663: /* Allwinner F1C100s/F1C600/R6/F1C100A/F1C500 */
+		gpio_set_cfgpin(dev, PC, 0, SUNIV_GPC_SPI0);
+		gpio_set_cfgpin(dev, PC, 1, SUNIV_GPC_SPI0);
+		gpio_set_cfgpin(dev, PC, 2, SUNIV_GPC_SPI0);
+		gpio_set_cfgpin(dev, PC, 3, SUNIV_GPC_SPI0);
+		break;
 	case 0x1625: /* Allwinner A13 */
 	case 0x1680: /* Allwinner H3 */
 	case 0x1681: /* Allwinner V3s */
@@ -267,11 +278,28 @@ static bool spi0_init(feldev_handle *dev)
 		writel(reg_val, CCM_AHB_GATING0);
 	}
 
-	/* divide by 4 */
-	writel(CCM_SPI0_CLK_DIV_BY_4, spi_is_sun6i(dev) ? SUN6I_SPI0_CCTL :
-							  SUN4I_SPI0_CCTL);
-	/* Choose 24MHz from OSC24M and enable clock */
-	writel(1U << 31, soc_is_h6_style(dev) ? H6_CCM_SPI0_CLK : CCM_SPI0_CLK);
+	if (soc_info->soc_id == 0x1663) {	/* suniv F1C100s */
+		/*
+		 * suniv doesn't have a module clock for SPI0 and the clock
+		 * source is always the AHB clock. Setup AHB to 200 MHz by
+		 * setting PLL6 to 600 MHz with a divider of 3, then program
+		 * the internal SPI dividier to 32.
+		 */
+
+		/* Set PLL6 to 600MHz */
+		writel(0x80041801, SUNIV_PLL6_CTL);
+		/* PLL6:AHB:APB = 6:2:1 */
+		writel(0x00003180, SUNIV_AHB_APB_CFG);
+		/* divide by 32 */
+		writel(CCM_SPI0_CLK_DIV_BY_32, SUN6I_SPI0_CCTL);
+	} else {
+		/* divide 24MHz OSC by 4 */
+		writel(CCM_SPI0_CLK_DIV_BY_4,
+		       spi_is_sun6i(dev) ? SUN6I_SPI0_CCTL : SUN4I_SPI0_CCTL);
+		/* Choose 24MHz from OSC24M and enable clock */
+		writel(1U << 31,
+		       soc_is_h6_style(dev) ? H6_CCM_SPI0_CLK : CCM_SPI0_CLK);
+	}
 
 	if (spi_is_sun6i(dev)) {
 		/* Enable SPI in the master mode and do a soft reset */

--- a/fel.c
+++ b/fel.c
@@ -623,9 +623,14 @@ uint32_t *aw_backup_and_disable_mmu(feldev_handle *dev,
 	 * checks needs to be relaxed).
 	 */
 
-	/* Basically, ignore M/Z/I/V/UNK bits and expect no TEX remap */
+	/*
+	 * Basically, ignore M/Z/I/V/UNK bits and expect no TEX remap.
+	 * Bits [23:22] are Read-As-One on ARMv7, but Should-Be-Zero
+	 * on ARMv5, so ignore them.
+	 * We need the RES1 bits[18,16,4,3] and CP15BEN[5].
+	 */
 	sctlr = aw_get_sctlr(dev, soc_info);
-	if ((sctlr & ~((0x7 << 11) | (1 << 6) | 1)) != 0x00C50038)
+	if ((sctlr & ~((0x3 << 22) | (0x7 << 11) | (1 << 6) | 1)) != 0x00050038)
 		pr_fatal("Unexpected SCTLR (%08X)\n", sctlr);
 
 	if (!(sctlr & 1)) {

--- a/soc_info.c
+++ b/soc_info.c
@@ -271,6 +271,7 @@ soc_info_t soc_info_table[] = {
 		.swap_buffers = f1c100s_sram_swap_buffers,
 		.sram_size    = 32 * 1024,
 		/* No SID */
+		.watchdog     = &wd_h3_compat,
 	},{
 		.soc_id       = 0x1673, /* Allwinner A83T */
 		.name         = "A83T",

--- a/soc_info.c
+++ b/soc_info.c
@@ -145,6 +145,23 @@ sram_swap_buffers r329_sram_swap_buffers[] = {
 	{ .size = 0 }  /* End of the table */
 };
 
+/*
+ * The FEL code from BROM in F1C100s also uses SRAM A in a similar way
+ * with A10/A13/A20.
+ * Unfortunately the SRAM layout of F1C100s is not documented at all, so
+ * we can only try by r/w under FEL mode.
+ * The result is that there's a contingous SRAM zone from 0x8800 to 0xb5ff.
+ */
+sram_swap_buffers f1c100s_sram_swap_buffers[] = {
+	/* 0x1C00-0x1FFF (IRQ stack) */
+	{ .buf1 = 0x1C00, .buf2 = 0x9000, .size = 0x0400 },
+	/* 0x5C00-0x6FFF (Stack) */
+	{ .buf1 = 0x5C00, .buf2 = 0x9400, .size = 0x1400 },
+	/* 0x7C00-0x7FFF (Something important) */
+	{ .buf1 = 0x7C00, .buf2 = 0xa800, .size = 0x0400 },
+	{ .size = 0 }  /* End of the table */
+};
+
 const watchdog_info wd_a10_compat = {
 	.reg_mode = 0x01C20C94,
 	.reg_mode_value = 3,
@@ -246,6 +263,14 @@ soc_info_t soc_info_table[] = {
 		.sid_base     = 0X01C0E000,
 		.sid_offset   = 0x200,
 		.watchdog     = &wd_a80,
+	},{
+		.soc_id       = 0x1663, /* Allwinner F1C100s (all new sun3i?) */
+		.name         = "F1C100s",
+		.scratch_addr = 0x1000,
+		.thunk_addr   = 0xb400, .thunk_size = 0x200,
+		.swap_buffers = f1c100s_sram_swap_buffers,
+		.sram_size    = 32 * 1024,
+		/* No SID */
 	},{
 		.soc_id       = 0x1673, /* Allwinner A83T */
 		.name         = "A83T",

--- a/thunks/Makefile
+++ b/thunks/Makefile
@@ -27,7 +27,7 @@ AWK_O_TO_H := LC_ALL=C awk -f objdump_to_h.awk
 # The SPL thunk requires a different output format. The "style" variable for
 # awk controls this, and causes the htole32() conversion to be omitted.
 fel-to-spl-thunk.h: fel-to-spl-thunk.S FORCE
-	$(AS) -o $(subst .S,.o,$<) $<
+	$(AS) -o $(subst .S,.o,$<) -march=armv5te $<
 	$(OBJDUMP) -d $(subst .S,.o,$<) | $(AWK_O_TO_H) -v style=old > $@
 
 $(THUNKS): %.h: %.S FORCE

--- a/thunks/Makefile
+++ b/thunks/Makefile
@@ -31,5 +31,5 @@ fel-to-spl-thunk.h: fel-to-spl-thunk.S FORCE
 	$(OBJDUMP) -d $(subst .S,.o,$<) | $(AWK_O_TO_H) -v style=old > $@
 
 $(THUNKS): %.h: %.S FORCE
-	$(AS) -o $(subst .S,.o,$<) $<
+	$(AS) -o $(subst .S,.o,$<) -march=armv5te $<
 	$(OBJDUMP) -d $(subst .S,.o,$<) | $(AWK_O_TO_H) > $@

--- a/thunks/fel-to-spl-thunk.S
+++ b/thunks/fel-to-spl-thunk.S
@@ -21,45 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-/*************************************************************************/
-/* Usage instructions: "ruby -x fel-to-spl-thunk.S > fel-to-spl-thunk.h" */
-/*************************************************************************/
-
-/* Open a comment for gas.
-
-   Do not close the comment until after the Ruby code terminator (__END__).
-   Write the '*' '/' sequence of characters as "\x2a/" in string literals to
-   avoid doing so.
-
-#!/usr/bin/env ruby
-
-def tool_exists(tool_name)
-    `which #{tool_name} > /dev/null 2>&1`
-    return $?.to_i == 0
-end
-
-toolchains = [
-  "arm-none-eabi-",
-  "arm-linux-gnueabihf-",
-  "arm-none-linux-gnueabi-",
-  "armv7a-hardfloat-linux-gnueabi-",
-]
-
-toolchain = toolchains.find { |toolchain| tool_exists("#{toolchain}as") }
-abort "Can't find any ARM crosscompiler\n" unless toolchain
-
-system("#{toolchain}as -o #{$PROGRAM_NAME}.o #{$PROGRAM_NAME}")
-exit($?.to_i) if $?.to_i != 0
-
-`#{toolchain}objdump -d #{$PROGRAM_NAME}.o`.each_line {|l|
-    next unless l =~ /(\h+)\:\s+(\h+)\s+(\S+)\s+([^;]*)/
-    printf("\t0x%s, /* %8s:    %-10s %-28s \x2a/\n", $2, $1, $3, $4.strip)
-}
-
-__END__
-*/
-
-/*************************************************************************/
+.arm
 
 BUF1		.req	r0
 BUF2		.req	r1
@@ -75,14 +37,7 @@ entry_point:
 	b	setup_stack
 
 stack_begin:
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
-	nop
+	.space	32, 0xff
 stack_end:
 	nop
 
@@ -118,15 +73,14 @@ setup_stack: /* Save the original SP, LR and CPSR to stack */
 
 	/* Check if the instructions or data cache is enabled */
 	mrc	p15, 0, TMP1, c1, c0, 0
-	movw	TMP2,      #((1 << 12) | (1 << 2))
-	tst	TMP1,      TMP2
+	tst	TMP1,      #(1 << 2)
+	tsteq	TMP1,      #(1 << 12)
 	bne	cache_is_unsupported
 
 	bl	swap_all_buffers
 
 verify_checksum:
-	movw	CHECKSUM,  #0x6c39
-	movt	CHECKSUM,  #0x5f0a
+	ldr	CHECKSUM,  checksum_seed
 	mov	BUF1,      SPL_ADDR
 	ldr     FULLSIZE,  [BUF1, #16]
 check_next_word:
@@ -140,13 +94,18 @@ check_next_word:
 	bne	checksum_is_bad
 
 	/* Change 'eGON.BT0' -> 'eGON.FEL' */
-	movw	TMP1,      (('F' << 8) + '.')
-	movt	TMP1,      (('L' << 8) + 'E')
+	ldr	TMP1,	   egon_fel_str
 	str	TMP1,      [SPL_ADDR, #8]
 
-	/* Call the SPL code */
-	dsb
-	isb
+	/*
+	 * Call the SPL code
+	 * The "dsb" and "isb" instructions are not available in ARMv5TE.
+	 * We checked our SCTLR before (in fel.c) to have CP15BEN set,
+	 * so we know that CP15 barriers work in ARMv7+ cores.
+	 * The TMP1 register input is ignored by the instructions.
+	 */
+	mcr	p15, 0, TMP1, c7, c10, 4	/* CP15DSB */
+	mcr	p15, 0, TMP1, c7, c5, 4		/* CP15ISB */
 	blx	SPL_ADDR
 
 	/* Return back to FEL */
@@ -154,15 +113,13 @@ check_next_word:
 
 cache_is_unsupported:
 	/* Bail out if cache is enabled and change 'eGON.BT0' -> 'eGON.???' */
-	movw	TMP1,      (('?' << 8) + '.')
-	movt	TMP1,      (('?' << 8) + '?')
+	ldr	TMP1,	   cache_enabled_str
 	str	TMP1,      [SPL_ADDR, #8]
 	b	return_to_fel_noswap
 
 checksum_is_bad:
 	/* The checksum test failed, so change 'eGON.BT0' -> 'eGON.BAD' */
-	movw	TMP1,      (('B' << 8) + '.')
-	movt	TMP1,      (('D' << 8) + 'A')
+	ldr	TMP1,	   checksum_failed_str
 	str	TMP1,      [SPL_ADDR, #8]
 
 return_to_fel:
@@ -172,6 +129,15 @@ return_to_fel_noswap:
 	msr	cpsr_c,    TMP1 /* Restore the original CPSR */
 	ldr     sp,        [sp]
 	bx	lr
+
+checksum_seed:
+	.word	0x5f0a6c39
+egon_fel_str:
+	.ascii	".FEL"
+cache_enabled_str:
+	.ascii	".???"
+checksum_failed_str:
+	.ascii	".BAD"
 
 appended_data:
 /*

--- a/thunks/fel-to-spl-thunk.h
+++ b/thunks/fel-to-spl-thunk.h
@@ -1,14 +1,14 @@
 	/* <entry_point>: */
 	0xea000015, /*        0:    b          5c <setup_stack>             */
 	/* <stack_begin>: */
-	0xe1a00000, /*        4:    nop                                     */
-	0xe1a00000, /*        8:    nop                                     */
-	0xe1a00000, /*        c:    nop                                     */
-	0xe1a00000, /*       10:    nop                                     */
-	0xe1a00000, /*       14:    nop                                     */
-	0xe1a00000, /*       18:    nop                                     */
-	0xe1a00000, /*       1c:    nop                                     */
-	0xe1a00000, /*       20:    nop                                     */
+	0xffffffff, /*        4:    .word      0xffffffff                   */
+	0xffffffff, /*        8:    .word      0xffffffff                   */
+	0xffffffff, /*        c:    .word      0xffffffff                   */
+	0xffffffff, /*       10:    .word      0xffffffff                   */
+	0xffffffff, /*       14:    .word      0xffffffff                   */
+	0xffffffff, /*       18:    .word      0xffffffff                   */
+	0xffffffff, /*       1c:    .word      0xffffffff                   */
+	0xffffffff, /*       20:    .word      0xffffffff                   */
 	/* <stack_end>: */
 	0xe1a00000, /*       24:    nop                                     */
 	/* <swap_all_buffers>: */
@@ -37,43 +37,47 @@
 	0xe38220c0, /*       74:    orr        r2, r2, #192                 */
 	0xe121f002, /*       78:    msr        CPSR_c, r2                   */
 	0xee112f10, /*       7c:    mrc        15, 0, r2, cr1, cr0, {0}     */
-	0xe3013004, /*       80:    movw       r3, #4100                    */
-	0xe1120003, /*       84:    tst        r2, r3                       */
-	0x1a000012, /*       88:    bne        d8 <cache_is_unsupported>    */
+	0xe3120004, /*       80:    tst        r2, #4                       */
+	0x03120a01, /*       84:    tsteq      r2, #4096                    */
+	0x1a000010, /*       88:    bne        d0 <cache_is_unsupported>    */
 	0xebffffe5, /*       8c:    bl         28 <swap_all_buffers>        */
 	/* <verify_checksum>: */
-	0xe3067c39, /*       90:    movw       r7, #27705                   */
-	0xe3457f0a, /*       94:    movt       r7, #24330                   */
-	0xe1a00008, /*       98:    mov        r0, r8                       */
-	0xe5905010, /*       9c:    ldr        r5, [r0, #16]                */
+	0xe59f7060, /*       90:    ldr        r7, [pc, #96]                */
+	0xe1a00008, /*       94:    mov        r0, r8                       */
+	0xe5905010, /*       98:    ldr        r5, [r0, #16]                */
 	/* <check_next_word>: */
-	0xe4902004, /*       a0:    ldr        r2, [r0], #4                 */
-	0xe2555004, /*       a4:    subs       r5, r5, #4                   */
-	0xe0877002, /*       a8:    add        r7, r7, r2                   */
-	0x1afffffb, /*       ac:    bne        a0 <check_next_word>         */
-	0xe598200c, /*       b0:    ldr        r2, [r8, #12]                */
-	0xe0577082, /*       b4:    subs       r7, r7, r2, lsl #1           */
-	0x1a00000a, /*       b8:    bne        e8 <checksum_is_bad>         */
-	0xe304262e, /*       bc:    movw       r2, #17966                   */
-	0xe3442c45, /*       c0:    movt       r2, #19525                   */
-	0xe5882008, /*       c4:    str        r2, [r8, #8]                 */
-	0xf57ff04f, /*       c8:    dsb        sy                           */
-	0xf57ff06f, /*       cc:    isb        sy                           */
-	0xe12fff38, /*       d0:    blx        r8                           */
-	0xea000006, /*       d4:    b          f4 <return_to_fel>           */
+	0xe4902004, /*       9c:    ldr        r2, [r0], #4                 */
+	0xe2555004, /*       a0:    subs       r5, r5, #4                   */
+	0xe0877002, /*       a4:    add        r7, r7, r2                   */
+	0x1afffffb, /*       a8:    bne        9c <check_next_word>         */
+	0xe598200c, /*       ac:    ldr        r2, [r8, #12]                */
+	0xe0577082, /*       b0:    subs       r7, r7, r2, lsl #1           */
+	0x1a000008, /*       b4:    bne        dc <checksum_is_bad>         */
+	0xe59f203c, /*       b8:    ldr        r2, [pc, #60]                */
+	0xe5882008, /*       bc:    str        r2, [r8, #8]                 */
+	0xee072f9a, /*       c0:    mcr        15, 0, r2, cr7, cr10, {4}    */
+	0xee072f95, /*       c4:    mcr        15, 0, r2, cr7, cr5, {4}     */
+	0xe12fff38, /*       c8:    blx        r8                           */
+	0xea000004, /*       cc:    b          e4 <return_to_fel>           */
 	/* <cache_is_unsupported>: */
-	0xe3032f2e, /*       d8:    movw       r2, #16174                   */
-	0xe3432f3f, /*       dc:    movt       r2, #16191                   */
-	0xe5882008, /*       e0:    str        r2, [r8, #8]                 */
-	0xea000003, /*       e4:    b          f8 <return_to_fel_noswap>    */
+	0xe59f2028, /*       d0:    ldr        r2, [pc, #40]                */
+	0xe5882008, /*       d4:    str        r2, [r8, #8]                 */
+	0xea000002, /*       d8:    b          e8 <return_to_fel_noswap>    */
 	/* <checksum_is_bad>: */
-	0xe304222e, /*       e8:    movw       r2, #16942                   */
-	0xe3442441, /*       ec:    movt       r2, #17473                   */
-	0xe5882008, /*       f0:    str        r2, [r8, #8]                 */
+	0xe59f2020, /*       dc:    ldr        r2, [pc, #32]                */
+	0xe5882008, /*       e0:    str        r2, [r8, #8]                 */
 	/* <return_to_fel>: */
-	0xebffffcb, /*       f4:    bl         28 <swap_all_buffers>        */
+	0xebffffcf, /*       e4:    bl         28 <swap_all_buffers>        */
 	/* <return_to_fel_noswap>: */
-	0xe8bd4004, /*       f8:    pop        {r2, lr}                     */
-	0xe121f002, /*       fc:    msr        CPSR_c, r2                   */
-	0xe59dd000, /*      100:    ldr        sp, [sp]                     */
-	0xe12fff1e, /*      104:    bx         lr                           */
+	0xe8bd4004, /*       e8:    pop        {r2, lr}                     */
+	0xe121f002, /*       ec:    msr        CPSR_c, r2                   */
+	0xe59dd000, /*       f0:    ldr        sp, [sp]                     */
+	0xe12fff1e, /*       f4:    bx         lr                           */
+	/* <checksum_seed>: */
+	0x5f0a6c39, /*       f8:    .word      0x5f0a6c39                   */
+	/* <egon_fel_str>: */
+	0x4c45462e, /*       fc:    .word      0x4c45462e                   */
+	/* <cache_enabled_str>: */
+	0x3f3f3f2e, /*      100:    .word      0x3f3f3f2e                   */
+	/* <checksum_failed_str>: */
+	0x4441422e, /*      104:    .word      0x4441422e                   */

--- a/thunks/rmr-thunk.S
+++ b/thunks/rmr-thunk.S
@@ -1,6 +1,8 @@
 /*
  * Request AArch32/AArch64 warm reset, using RVBAR and Reset Management Register
+ * This is used on ARMv8 cores only, so force v7 code to allow dsb and isb.
  */
+.arch	armv7-a
 
 rmr_request:
 	ldr	r0, 1f	/* RVBAR register address */


### PR DESCRIPTION
F1C100s SoC has the watchdog compatible with H3, so let's assign
wd_h3_compat pointer to .watchdog member to allowa using 'wdreset' command.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>